### PR TITLE
Remove broken link to Google+

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -35,7 +35,6 @@ LINKS = (('Taiga.io', 'https://taiga.io'),
 # Social widget
 SOCIAL = (('Twitter', 'http://twitter.com/taigaio'),
           ('Github', 'https://github.com/taigaio'),
-          ('Google+', 'https://plus.google.com/+TaigaIo'),
 )
 
 DEFAULT_PAGINATION = 10


### PR DESCRIPTION
Google+ is closed, the link is broken.